### PR TITLE
msm8998-common: set vendor security patch level

### DIFF
--- a/common.mk
+++ b/common.mk
@@ -425,6 +425,10 @@ PRODUCT_PACKAGES += \
     android.hardware.usb@1.0-service \
     com.android.future.usb.accessory
 
+# Vendor security patch level
+PRODUCT_PROPERTY_OVERRIDES += \
+    ro.lineage.build.vendor_security_patch=2018-05-05
+
 # Vibrator
 PRODUCT_PACKAGES += \
     android.hardware.vibrator@1.0-impl \


### PR DESCRIPTION
Matches OxygenOS 5.1.2

Change-Id: I365d9b1ef63d8617ef4be1d8e58334ead2f28e25
Signed-off-by: Joey <joey@lineageos.org>