### PR TITLE
oneplus-msm8998: Drop deprecated OpenGLRenderer props

### DIFF
--- a/common.mk
+++ b/common.mk
@@ -36,20 +36,6 @@ PRODUCT_PROPERTY_OVERRIDES += \
     dalvik.vm.heapminfree=4m \
     dalvik.vm.heapmaxfree=8m
 
-# HWUI
-PRODUCT_PROPERTY_OVERRIDES += \
-    ro.hwui.texture_cache_size=96 \
-    ro.hwui.layer_cache_size=64 \
-    ro.hwui.r_buffer_cache_size=12 \
-    ro.hwui.path_cache_size=39 \
-    ro.hwui.gradient_cache_size=1 \
-    ro.hwui.drop_shadow_cache_size=7 \
-    ro.hwui.texture_cache_flushrate=0.4 \
-    ro.hwui.text_small_cache_width=2048 \
-    ro.hwui.text_small_cache_height=2048 \
-    ro.hwui.text_large_cache_width=3072 \
-    ro.hwui.text_large_cache_height=4096
-
 # Permissions
 PRODUCT_COPY_FILES += \
     frameworks/native/data/etc/android.hardware.audio.low_latency.xml:$(TARGET_COPY_OUT_VENDOR)/etc/permissions/android.hardware.audio.low_latency.xml \


### PR DESCRIPTION
 * In Android 8.1 and later, only the ro.zygote.disable_gl_preload
   property still applies. All other properties have been removed.
   Reference: https://source.android.com/devices/graphics/renderer

Change-Id: Ib43c22ea3285e5fe397da8a7a5cac1c3a27a2f36